### PR TITLE
Add PriceHistories

### DIFF
--- a/app/assets/stylesheets/components/_subscription.css
+++ b/app/assets/stylesheets/components/_subscription.css
@@ -16,9 +16,41 @@
 
 .subscription-card-header {
     display: flex;
+    justify-content: space-between;
+    align-items: first baseline;
+    margin-bottom: 1.5rem;
+}
+
+.subscription-name {
+    display: flex;
     align-items: first baseline;
     gap: 0.25rem;
-    margin-bottom: 1.5rem;
+}
+
+.subscription-price-change-percentage .no-price-change::after {
+    content: " 😇"
+}
+
+.subscription-price-change-percentage .moderate-price-change {
+    color: var(--color-secondary);
+}
+
+.subscription-price-change-percentage .moderate-price-change::after {
+    content: " 😢"
+}
+
+.subscription-price-change-percentage .large-price-change,
+.subscription-price-change-percentage .absurd-price-change {
+    color: var(--color-primary);
+    font-weight: 700;
+}
+
+.subscription-price-change-percentage .large-price-change::after {
+    content: " 😭"
+}
+
+.subscription-price-change-percentage .absurd-price-change::after {
+    content: " 💀"
 }
 
 .subscription img {

--- a/app/helpers/subscriptions_helper.rb
+++ b/app/helpers/subscriptions_helper.rb
@@ -6,4 +6,25 @@ module SubscriptionsHelper
   def total_annually
     current_user.subscriptions.sum(&:annual_price)
   end
+
+  def percentage_increase_text(subscription)
+    span_class = "no-price-change"
+    text = "No price changes"
+
+    if subscription.price_change_percentage > 0.00
+      span_class = "moderate-price-change"
+      text = "Price increased #{number_to_percentage subscription.price_change_percentage, precision: 0}"
+    end
+
+    if subscription.price_change_percentage >= 50.00
+      span_class = "large-price-change"
+      text += "!"
+    end
+
+    if subscription.price_change_percentage >= 100.00
+      span_class = "absurd-price-change"
+    end
+
+    "<span class=\"#{span_class}\">#{text}</span>".html_safe
+  end
 end

--- a/app/models/price_history.rb
+++ b/app/models/price_history.rb
@@ -1,0 +1,5 @@
+class PriceHistory < ApplicationRecord
+  belongs_to :subscription
+
+  enum :price_type, %i[ monthly annually ]
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,12 +4,33 @@ class Subscription < ApplicationRecord
 
   enum :price_type, %i[ monthly annually ]
 
+  has_many :price_histories, dependent: :destroy
   belongs_to :user
+
+  before_save :track_price_change
 
   scope :sort_by_name, -> { order(name: :asc) }
 
   def self.currency
     ENV.fetch("CURRENCY", "").presence || "$"
+  end
+
+  def price_change_percentage
+    return Float::INFINITY if initial_monthly_price.zero?
+
+    ((monthly_price - initial_monthly_price) / initial_monthly_price.to_f * 100)
+  end
+
+  def initial_monthly_price
+    (first_price_history.monthly? ? first_price_history.price : first_price_history.price / 12)
+  end
+
+  def initial_annual_price
+    (first_price_history.annually? ? first_price_history.price : first_price_history.price * 12)
+  end
+
+  def first_price_history
+    @earliest_price_history ||= price_histories.order(effective_date: :asc).first
   end
 
   def monthly_price
@@ -30,5 +51,17 @@ class Subscription < ApplicationRecord
     return unless url
 
     ::Addressable::URI.parse(url).host
+  end
+
+  private
+
+  def track_price_change
+    if price_changed? || price_type_changed?
+      price_histories.build(
+        price: price,
+        price_type: price_type,
+        effective_date: created_at&.to_datetime || Time.current
+      )
+    end
   end
 end

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -1,8 +1,13 @@
 <%= turbo_frame_tag subscription do %>
     <div class="subscription">
         <div class="subscription-card-header">
-            <img src="<%= subscription.icon %>">
-            <h2><%= subscription.name %></h2>
+            <div class="subscription-name">
+                <img src="<%= subscription.icon %>">
+                <h2><%= subscription.name %></h2>
+            </div>
+            <div class="subscription-price-change-percentage">
+                <p><%= percentage_increase_text(subscription) %></p>
+            </div>
         </div>
         <div class="subscription-footer">
             <h3>Monthly Cost: <%= number_to_currency subscription.monthly_price, precision: 2, unit: Subscription.currency %></h3>

--- a/db/migrate/20241014230001_create_price_histories.rb
+++ b/db/migrate/20241014230001_create_price_histories.rb
@@ -1,0 +1,12 @@
+class CreatePriceHistories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :price_histories do |t|
+      t.references :subscription, null: false, foreign_key: true
+      t.decimal :price
+      t.datetime :effective_date
+      t.integer :price_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_14_020423) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_14_230001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "price_histories", force: :cascade do |t|
+    t.bigint "subscription_id", null: false
+    t.decimal "price"
+    t.datetime "effective_date"
+    t.integer "price_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subscription_id"], name: "index_price_histories_on_subscription_id"
+  end
 
   create_table "subscriptions", force: :cascade do |t|
     t.string "name", null: false
@@ -33,5 +43,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_020423) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "price_histories", "subscriptions"
   add_foreign_key "subscriptions", "users"
 end

--- a/test/fixtures/price_histories.yml
+++ b/test/fixtures/price_histories.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  subscription: one
+  price: 9.99
+  effective_date: 2024-10-14 23:00:01
+  price_type: 1
+
+two:
+  subscription: two
+  price: 9.99
+  effective_date: 2024-10-14 23:00:01
+  price_type: 1

--- a/test/models/price_history_test.rb
+++ b/test/models/price_history_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PriceHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Adds a PriceHistory model so that users can have a record of price changes over time.  Initial implementation displays the % change in cost between the initial price captured and the current price.  Hopefully this makes it easier to track which services are price gouging and make better decisions about which ones to keep/cancel.