### PR TITLE
Support Subscribed On Dates & Renewal Dates

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -56,6 +56,6 @@ class SubscriptionsController < ApplicationController
   end
 
   def subscription_params
-    params.require(:subscription).permit(:name, :url, :price_type, :price)
+    params.require(:subscription).permit(:name, :url, :price_type, :price, :subscribed_on)
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -16,6 +16,35 @@ class Subscription < ApplicationRecord
     ENV.fetch("CURRENCY", "").presence || "$"
   end
 
+  def renews_this_week?
+    return false unless subscribed_on.present?
+
+    (renews_on - Date.current).to_i <= 7
+  end
+
+  def renews_on
+    return unless subscribed_on.present?
+
+    current_date = Date.current
+    next_renewal = nil
+
+    if monthly?
+      next_renewal = subscribed_on.next_month
+
+      while next_renewal < current_date
+        next_renewal = next_renewal.next_month
+      end
+    else
+      next_renewal = subscribed_on.next_year
+
+      while next_renewal < current_date
+        next_renewal = next_renewal.next_year
+      end
+    end
+
+    next_renewal
+  end
+
   def price_change_percentage
     return Float::INFINITY if initial_monthly_price.zero?
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,6 +1,7 @@
 class Subscription < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0.00 }
+  validate  :subscribed_on_cannot_be_in_future
 
   enum :price_type, %i[ monthly annually ]
 
@@ -54,6 +55,12 @@ class Subscription < ApplicationRecord
   end
 
   private
+
+  def subscribed_on_cannot_be_in_future
+    if subscribed_on.present? && subscribed_on > Date.current
+        errors.add(:subscribed_on, "cannot be in the future")
+    end
+  end
 
   def track_price_change
     if price_changed? || price_type_changed?

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -16,6 +16,10 @@
             <%= f.label :price, "Price in #{Subscription.currency}" %>
             <%= f.number_field :price, step: :any %>
         </div>
+        <div class="form-row">
+            <%= f.label :subscribed_on %>
+            <%= f.date_field :subscribed_on %>
+        </div>
         <div class="form-actions">
             <%= link_to "Cancel", subscriptions_path %>
             <%= f.submit %>

--- a/app/views/subscriptions/_subscription.html.erb
+++ b/app/views/subscriptions/_subscription.html.erb
@@ -1,6 +1,9 @@
 <%= turbo_frame_tag subscription do %>
     <div class="subscription">
         <div class="subscription-card-header">
+            <% if subscription.renews_this_week? %>
+              <p>Renews this week!</p>
+            <% end %>
             <div class="subscription-name">
                 <img src="<%= subscription.icon %>">
                 <h2><%= subscription.name %></h2>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Subscriptions
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Eastern Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
     Dotenv::Rails.load

--- a/db/migrate/20241022011135_add_subscribed_on_date_to_subscriptions.rb
+++ b/db/migrate/20241022011135_add_subscribed_on_date_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddSubscribedOnDateToSubscriptions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :subscriptions, :subscribed_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_14_230001) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_22_011135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "price_histories", force: :cascade do |t|
     t.bigint "subscription_id", null: false
@@ -32,6 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_230001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.date "subscribed_on"
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
@@ -43,6 +72,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_230001) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "price_histories", "subscriptions"
   add_foreign_key "subscriptions", "users"
 end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -8,6 +8,7 @@ class SubscriptionTest < ActiveSupport::TestCase
       name: "My Subscription",
       price_type: Subscription.price_types[:monthly],
       price: 10.55.to_d,
+      subscribed_on: Date.current,
       user: @user
     )
   end
@@ -57,6 +58,13 @@ class SubscriptionTest < ActiveSupport::TestCase
 
       _(@subscription).must_be :invalid?
       _(@subscription.errors[:price]).must_include "must be greater than or equal to 0.0"
+    end
+
+    it "cannot have a subscribed_on date in the future" do
+      @subscription.subscribed_on = Date.current + 1.day
+
+      _(@subscription).must_be :invalid?
+      _(@subscription.errors[:subscribed_on]).must_include "cannot be in the future"
     end
   end
 


### PR DESCRIPTION
Resolves #18.  This sets up a new column for specifying the date on which a user enrolled in a subscription.  The application can then work from the current date and recurring type to figure out when the next renewal date is.  For any subscriptions renewing within 1 week, display that info on the home page card.

This is just a simple implementation.  Future iterations could add something like a webhook that fires when a renewal is coming up.