### PR TITLE
Remove Redis & Selenium

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -18,19 +18,7 @@ services:
     # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
     depends_on:
-    - selenium
-    - redis
     - postgres
-
-  selenium:
-    image: selenium/standalone-chromium
-    restart: unless-stopped
-
-  redis:
-    image: redis:7.2
-    restart: unless-stopped
-    volumes:
-    - redis-data:/data
 
   postgres:
     image: postgres:16.1
@@ -44,5 +32,4 @@ services:
         POSTGRES_PASSWORD: postgres
 
 volumes:
-  redis-data:
   postgres-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,6 @@
 
   "containerEnv": {
     "CAPYBARA_SERVER_PORT": "45678",
-    "SELENIUM_HOST": "selenium",
-    "REDIS_URL": "redis://redis:6379/1",
     "DB_HOST": "postgres",
     "POSTGRES_USER": "postgres",
     "POSTGRES_PASSWORD": "postgres",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,6 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
@@ -89,7 +83,6 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-          # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,4 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: subscriptions_production
+  adapter: async


### PR DESCRIPTION
Don't need these, especially after upgrading to rails 8.  kind of wish i'd just stuck with sqlite instead of postgres for this simple app, too.  oh well.